### PR TITLE
Add coredump arg 

### DIFF
--- a/src/jymandra.ml
+++ b/src/jymandra.ml
@@ -37,7 +37,8 @@ let run_ count str : C.Kernel.exec_status_ok C.or_error Lwt.t =
   Log.logf "parse %S\n%!" str;
   if str = "##coredump" then
     let () = handle_coredump () in
-    (Result.Ok (C.Kernel.ok (Some "Coredump written."))) |> Lwt.return
+    (Result.Ok (C.Kernel.ok (Some "Coredump written.")))
+    |> Lwt.return
   else
     Lwt.catch
       (fun res ->


### PR DESCRIPTION
This adds the coredumping to jymandra in the same way as in the imandra main repl loop.

Currently only 'unexpected' lwt exceptions print coredumps, as AFAICT the other error handling paths are reached for user errors from some simple tests I did, and we don't want coredumps for every bad bit of user input, only for the really bad stuff.

I also deviated from the imandra coredump arg slightly and let the directory to write coredumps to be passed in as it makes life a bit easier on the coredump watcher side of things, and keeps the coredumps out of the user's notebook workspace.